### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as f:
 
 setuptools.setup(
     name='brighthive-authlib',
-    version='1.0.5',
+    version='1.1.0',
     author='Gregory Mundy',
     author_email='greg@brighthive.io',
     description='BrightHive API Authorization and Authentication Library',


### PR DESCRIPTION
Push version to 1.1.0 in order to remain consistent with versioning standards.